### PR TITLE
- added prebuilt-index

### DIFF
--- a/project/mkdocs.yml
+++ b/project/mkdocs.yml
@@ -3,7 +3,8 @@ repo_url: https://github.com/openSUSE/openSUSE-docs-revamped-temp
 edit_uri: ""
 
 plugins:
-    - search
+    - search:
+        prebuild_index: true
     - git-revision-date
     - mkdocs-versioning:
         version: 0.3.1


### PR DESCRIPTION
By using the `prebuilt_index` option we are able to produce an index consumed by the search plugin at build time. Even though we apparently already have such prebuilt index before turning on the setting, it seems to be formatted differently. Enabling this setting decreases the chances that other consumers of the index (like https://github.com/why-not-try-calmer/searchDocsBot/ and others) will choke when loading the index. 