### PR TITLE
Update pipewire documentation

### DIFF
--- a/project/docs/pipewire.md
+++ b/project/docs/pipewire.md
@@ -1,21 +1,25 @@
 ### What is pipewire?
 
 ### Installing
+
+Warning: This removes the package `pulseaudio`
+
 Install the package:
+
 ```
 sudo zypper in pipewire pipewire-pulseaudio
 ```
-Then enable the pipwire audio socket: 
+
+Then enable the pipwire audio socket:
+
 ```
-systemctl --user enable --now pipewire.{service,socket} pipewire-pulse.{service,socket}
-```
-Finally reboot your system:
-```
-systemctl reboot
+systemctl --user enable --now pipewire.{service,socket}
+systemctl --user enable --now pipewire-pulse.{service,socket}
+systemctl --user enable --now pipewire-media-session.service
 ```
 
-### For KDE Plasma users
-After rebooting, enable pipewire service making pipewire available to Plasma:
+Finally reboot your system:
+
 ```
-systemctl --user enable --now pipewire-media-session.service
+systemctl reboot
 ```

--- a/project/docs/pipewire.md
+++ b/project/docs/pipewire.md
@@ -1,5 +1,11 @@
 ### What is pipewire?
 
+According to the [pipewire website](https://pipewire.org/)
+
+> [It] is a project that aims to greatly improve handling of audio and video under Linux. It provides a low-latency, graph based processing engine on top of audio and video devices that can be used to support the use cases currently handled by both pulseaudio and JACK. PipeWire was designed with a powerful security model that makes interacting with audio and video devices from containerized applications easy, with supporting Flatpak applications being the primary goal. Alongside Wayland and Flatpak we expect PipeWire to provide a core building block for the future of Linux application development.
+
+TLDR; Pipewire is a new multimedia framework that aims for minimal latency and improved security with support for Pulseaudio, JACK, ALSA, and GStreamer.
+
 ### Installing
 
 Warning: This removes the package `pulseaudio`


### PR DESCRIPTION
The command `systemctl --user enable --now pipewire-media-session`
is not unique to the KDE Plasma desktop environment. The services are
DE/TWM agnostic. All three commands should be executed before rebooting.

EDIT: Also added a little bit of information about what pipewire is since it is empty.