### PR TITLE
power mgmt: Edit and expand Hibernation section etc.

### DIFF
--- a/project/docs/power.md
+++ b/project/docs/power.md
@@ -52,7 +52,7 @@ This has important consequences:
             ```
             Then close the admin prompt and reboot.
 
-*   Hibernation will not work if you use a swap _file_ in your root partition instead of a separate swap partition.
+*   Hibernation should but might not work if you use a swap _file_ in your root partition instead of a separate swap partition.
 
 *   Hibernation will not work if you use the `ZRAM` tool to swap into compressed RAM disks.
 

--- a/project/docs/power.md
+++ b/project/docs/power.md
@@ -1,77 +1,213 @@
 
 ## Power-saving methods
-On modern hardware Linux-based desktop environments favour a combination of the following methods for saving power:
+On modern hardware, Linux desktop environments generally use some combination of the following methods for saving power, often in this order:
 
-1. monitor dimming
-2. monitor suspension
-3. session / system suspension to RAM (so-called _suspension_)
-4. session / system suspension to disk (so-called _hibernation_)
+1. Dimming the monitor(s)
+2. Suspending the monitor(s)
+3. Suspending the system into RAM (also called _suspend-to-RAM_, _sleep_ or _suspend mode_)
+4. Suspending the system to disk (also called _suspend-to-disk_, _hibernation_ or _deep sleep_)
 
-_Monitor dimming_ (1), _Monitor suspension_ (2) and _Session suspension_ (3) should be easy to find: open your desktop environment's settings and search for _power management_. By contrast the last of these methods may require a few helpers.
+_Monitor dimming_, _monitor suspension_, and _suspend-to-RAM_ are usually enabled by default.
+To check whether they are enabled, open your desktop environment's settings and search for _power management_.
 
-## Suspension to disk (hibernation)
+In contrast, _hibernation_ may need to be set up manually.
 
-An openSUSE operating system is ready for hibernation only when:
 
-- _Swap exists_: A swap space on the disk must exist (see below for details)
-- _Swap referenced_: The swap space must be referenced in `/etc/fstab`, the configuration file read on every boot and used to mount and integrate the different spaces listed on the file into a proper file structure
-- _Resume referenced_: The partition to which the user wants the hibernation to resume to must be made known to the kernel, usually as the value of a kernel parameter
+## Suspend-to-disk (hibernation)
 
-Swap space can be created while partitioning the disk during installation or after installation.
+When it is running, your computer keeps all running programs and current state in memory (RAM).
+Suspend-to-RAM is a way to save energy by powering off most components of a computer, except its memory, meaning state is kept.
 
-__During installation__
+This is a quick way to enable a low-power mode but has an important drawback:
+It still requires a some power.
+If you put your laptop to sleep for long that its battery runs out of power, the laptop will turn off.
+This means you will lose any unsaved work and can also result in disk corruption.
+
+A secondary issue is that some events can wake the machine from sleep, and there is a risk of it overheating in a confined space.
+This includes connection and disconnection of USB devices or accidentally pressing external buttons or switches.
+
+Suspend-to-disk (hibernation) is different:
+The contents of the machine's memory are saved to disk, then the machine turns off completely.
+In this state it uses no power and will resume back to where you were an arbitrary length of time later.
+
+When Linux hibernates, it saves the contents of the memory to the swap partition.
+On the next boot, the kernel checks the swap partition and if it finds a suspend image there, it reads it back into memory and resumes operation.
+
+This has important consequences:
+
+*   Your machine must have a _dedicated_ swap _partition_.
+
+    *   If you use multiple Linux distributions side-by-side that share a swap partition, hibernation will have unpredictable results and will not work reliably.
+
+    *   If you dual-boot with Windows, there can also be problems. Two potential issues are:
+
+        *   If you use Windows' partition(s) under both OSes and hibernate Linux, boot Windows, and then resume Linux, this will result in disk corruption.
+            This happens because the contents of the partitions will have changed while Linux was in hibernation.
+
+        *   For related reasons, we recommend that you disable hibernation and "Fast Boot" in Windows.
+            "Fast Boot" can cause issues if you mount any Windows partitions via `/etc/fstab`.
+            To disable both settings, open command prompt in Administrator Mode and enter:
+            ```
+            powercfg -h off
+            ```
+            Then close the admin prompt and reboot.
+
+*   Hibernation will not work if you use a swap _file_ in your root partition instead of a separate swap partition.
+
+*   Hibernation will not work if you use the `ZRAM` tool to swap into compressed RAM disks.
+
+
+### Requirements for hibernation
+
+If you do have a dedicated partition, the following requirements must be met:
+
+*   _Swap exists_: A swap partition on the disk must exist (see below for details)
+
+*   _Swap is big enough_: the swap partition must be at least as big as the total amount of RAM fitted to the computer, and preferably slightly more.
+
+    *   There must be enough space in the partition to hold the entire contents of your computer's memory.
+        If your computer is short on RAM and so Linux normally uses swap space when running, then you need additional space for the memory image in addition to how much which is normally used.
+        Historically, when RAM was expensive and systems typically used swap heavily, users often allocated at least twice as much space for swap as there was RAM.
+        On modern computers with large amounts of RAM this usually is a waste of disk space.
+
+    *   We recommend the size of RAM + 1 GB.
+
+*   _Swap is referenced_: The swap space must be specified in `/etc/fstab`. This file specifies the various partitions to be mounted into the Linux file system and is read every time Linux boots.
+
+*   _Resume is referenced_: The partition to which system will hibernate must be made known to the kernel, usually as the value of a kernel parameter
+
+
+### Creating a swap partition
+
+A swap partition can be created while partitioning your disks during installation, or in a separate step after installation.
+
+
+#### During installation
 
 This is adapted from [the installation documentation](yast_installer.md#about-partition-schemes) and repeated here for convenience.
 
 <u>Step by step: Expert partitioning</u>
 
-1. From the _Disk_ view, select _Expert Partitioner_
-2. Click the __Add Partition__ button (bottom left-hand side)
-3. Add a `swap` partition with a size equal to your current RAM + 1 GB.
+1.  From the _Disk_ view, select _Expert Partitioner_
+2.  Click _Add Partition_ (bottom left-hand side)
+3.  Add a `swap` partition with a size equal to your current RAM + 1 GB.
 
-__After installing__
 
-From _YaST2_:
+#### After installation
 
-1. Click on, or search and then open, the _Partitioner_ module.
-2. Select __Disks__ from the list on your left-hand side, and take note of the identifier of the partition you will want to resume to. Note both the UUID and the `/dev/sda<number>` identifiers.
-3. Click on the __Create partition__ button. 
-3. Add a `swap` partition with a size equal to your current RAM + 1 GB, making sure to format it as `swap`
-4. Confirm to apply the changes.
+From _YaST_:
 
-Whichever method was used, by now YaST2 should have edited your `/etc/fstab` to reference the freshly created swap partition, which means that the conditions (Swap exists) and (Swap referenced) above should be met. You can double check that this is the case with
+You need a dedicated disk partition for swap. It does not matter where on the disk it is, so after your existing partitions is often convenient.
+
+If you have an existing partition you plan to use, you can skip the following two sections on partition creation.
+
+
+##### If the partition does not exist yet
+
+*   If your disk is partitioned with the GPT scheme, you can add another partition at the end.
+
+*   If it is partitioned with MBR, the old DOS partitioning scheme applies:
+
+    *   You can only have a maximum of four primary partitions, so you may want to make the new swap partition a logical partition inside the extended partition.
+
+    *  If an extended partition does not already exist, create one.
+
+    *  If you already have four primary partitions, you must remove one, or back up its contents to an external drive, remove it, create an extended partition and then copy its contents back into a new logical partition inside the extended partition.
+
+    *  Logical partitions are numbered starting at `/dev/sda5`, even if you only have 1 or 2 primary partitions.
+
+
+###### Creating a new swap partition
+
+1.  Boot from a Linux Live USB, such as the [openSUSE Live CD](https://download.opensuse.org/distribution/leap/15.3/live/)
+
+2.  Run the _GParted_ dynamic-partitioning tool.
+
+3.  Choose a partition from which you can spare some capacity.
+
+4.  Shrink your desired partition by the amount of space you wish to give to swap.
+
+5.  Create a new partition in the now-free space. Pick a type of `Linux swap`.
+
+6.  Reboot the computer and remove the bootable USB medium or optical disk.
+
+
+##### If the partition already exists
+
+1.  Open the _Partitioner_ module.
+
+2.  Select _Disks_ from the list on your left-hand side, and take note of the identifier of the partition you will want to resume to.
+    Note both the UUID and the `/dev/sda<number>` identifiers.
+
+3.  Click _Create partition_.
+
+4.  Add a `swap` partition with a size equal to your current RAM + 1 GB.
+    Make sure it is formatted as `swap`.
+
+5.  Confirm to apply the changes.
+
+
+### Testing your new swap partition
+
+Whichever method was used, by now _YaST_ should have edited your `/etc/fstab` file to reference the freshly created swap partition, which means that conditions 1 and 3 (swap exists and is referenced) above should be met.
+
+You can check that this is the case with the command:
 
 ```
 $ blkid | grep "swap"
 ```
 
-This command should return a line referencing various identifiers for your swap partition. You can compare the UUID visible from this context with the UUID listed in _YaST2_ for good measure (see step 2 above). If you have created the swap space during installation, don't forget to search for the UUID and the `/dev/sda<number>` identifiers referencing the partition you are resuming to.
+This command should return a line referencing various identifiers for your swap partition.
+You can compare the UUID visible from this context with the UUID listed in _YaST_ for good measure (see step 2 above).
+If you created the swap partition during installation, search for the UUID and the `/dev/sda<number>` identifiers referencing the partition your computer will resume to.
 
-Finally, to fulfill condition (Resume referenced), in _YaST2_:
-
-1. Click on, or search and then open, the _Bootloader_ module.
-2. Switch to the __Kernel Parameters__ tab.
-3. In the first text-field, labelled _Optional Kernel Parameters_, simply add the following text:
-```
-resume=/dev/sda<number> # replace '<number>' by the number of the target partition you want to resume to
+If you have rebooted your computer after creating the partition, you can check to see if your new swap partition is active with the following command:
 
 ```
-or
-```
-resume=UUID=<UUID> # replace '<UUID>' with the UUID of the partition you want to resume to.
+sudo swapon -s
 ```
 
-!!! warning
-    It's preferable to use the UUID over any other identifier for referencing partitions as UUID identifiers are not ambiguous. However, should you recreate a resume or swap partition referenced via UUID, the reference will break and you will need to register it again where appropriate (kernel parameters if resume partition, `/etc/fstab` if swap space.) 
-
-You can finally lay back and admire your configuration. On my machine it looks like this:
+If you have not yet rebooted and you wish to activate and start swapping onto the partition immediately, use the following command with the device name of your new partition:
 
 ```
-# kernel parameter
-`resume=UUID=19bd024f-76bd-4162-ac37-4d0d51e02c25`
+sudo swapon /dev/sda<number>
 ```
-and 
-```
-# /etc/fstab
-UUID=e0bac415-cbde-4c9b-8178-7874ac9de70a none swap defaults 0 0
-```
+
+Finally, make sure that the resume partition is referenced via _YaST_:
+
+1.  Open the _Bootloader_ module.
+
+2.  Switch to the _Kernel Parameters_ tab.
+
+3.  In the text field _Optional Kernel Parameters_, add the `resume` parameter and a reference to UUID of the partition you want to resume from:
+    ```
+    resume=UUID=<UUID> # replace '<UUID>' with the UUID
+    ```
+    Alternatively, you can use the partition number _(not recommended)_:
+    ```
+    resume=/dev/sda<number> # replace '<number>' with the partition number
+    ```
+
+!!! important
+    We recommend using UUIDs (_Universal Unique Identifier_) instead of other identifiers for referencing partitions.
+    UUIDs are unambiguous and do not change when other partitions are added or removed.
+
+    However, UUIDs will change if you reformat or delete and recreate a swap partition.
+    In such cases, update the UUID where appropriate.
+    For resume partitions, update the `resume` kernel parameter:
+    ```
+    resume=UUID=19bd024f-76bd-4162-ac37-4d0d51e02c25
+    ```
+    For swap space, update `/etc/fstab`:
+    ```
+    UUID=e0bac415-cbde-4c9b-8178-7874ac9de70a none swap defaults 0 0
+    ```
+
+When you are happy that the partition is in place and works, try the hibernate command of your desktop.
+This is often located next to the shut down, reboot and sleep commands.
+
+
+## More information
+
+You can read about testing and using hibernation functionality in the openSUSE Wiki:
+[SDB:Suspend to disk](https://en.opensuse.org/SDB:Suspend_to_disk).


### PR DESCRIPTION
The previous branches from Liam were a bit of a mess (#59 & #60), so I have started to separate the software installer and power management changes he made.

**These are just the power management things,** rebased on top of the current `dev` branch.

I have also reformatted the file to [one-sentence-per-line style](https://asciidoctor.org/docs/asciidoc-recommended-practices/#one-sentence-per-line), because that will make things more readable and diffable in the future.
I realize that sentence-per-line is not the canonical style for Markdown, but it does have major advantages when working with text in Git and MkDocs actually seems to support it. :)

I have added a few changes of my own... I guess there is a chance that this has introduced errors too.

The following comments from the [original PR](https://github.com/openSUSE/openSUSE-docs-revamped-temp/pull/60/commits/cb200fc1ca52528c2d62de889dba11e08e9da536) are not yet handled, and I am frankly out of my depth on those. The best I could do is to use somewhat softer wording.

```diff
+ * You must have a _dedicated_ swap _partition_.
```
>  Ethanol6 on 21 Oct 2021
> > Does openSUSE default install create a swap partition? Is a swap file an option?
> 
> why-not-try-calmer on 21 Oct 2021
> The Yast2 installer of Leap/TW has too many alternative "views" (Expert, Guided, etc.) to answer this with a Yes or No. What is an absolute Yes is that hibernation requires a swap block, be it a physical partition or a file. If I remember when doing my research on this topic I went for a "partition" by default as it it much easier to use and troubleshoot.

and

```diff
+  * Hibernation will not work if you use a swap _file_ in your root partition instead of a separate swap partition.
```
> Ethanol6 on 21 Oct 2021
> > Is this an openSUSE or BTRFS thing? I use swap files on other distros and hibernation works fine.
