### PR TITLE
Flatpak/flathub user install and Nvidia auto-detect 

### DIFF
--- a/project/docs/best_of_post.md
+++ b/project/docs/best_of_post.md
@@ -47,7 +47,7 @@ Flatpaks are covered in more details in this guide, but they are an invaluable s
 $   sudo zypper in flatpak
 $   flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
 ```
-dd the flatpak repo as user to enable auto-updates without the need of a root password: 
+add the flatpak repo as user to enable auto-updates without the need of a root password: 
 ```
 $   sudo zypper in flatpak
 $   flatpak --user remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo

--- a/project/docs/best_of_post.md
+++ b/project/docs/best_of_post.md
@@ -47,6 +47,15 @@ Flatpaks are covered in more details in this guide, but they are an invaluable s
 $   sudo zypper in flatpak
 $   flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
 ```
+dd the flatpak repo as user to enable auto-updates without the need of a root password: 
+```
+$   sudo zypper in flatpak
+$   flatpak --user remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
+```
+To switch from a system-wide installation to the user variant, you'll need to first remove the old repo and then follow the steps shown above. (Note that this step will remove all your installed flatpaks)
+```
+$   flatpak remote-delete flathub
+```
 
 ### Customize your .desktop files for a better user experience
 Most user applications shipping their own GUI install with a desktop file (`<program name>.desktop`) providing the application with some parameters discovered at the installation. Some of these parameters are key to a comfortable user experience.

--- a/project/docs/install_proprietary.md
+++ b/project/docs/install_proprietary.md
@@ -23,7 +23,7 @@
 
 #### Using the command line
 1. Add the Nvidia Repository. If using Tumbleweed for example, you would run `sudo zypper addrepo --refresh https://download.nvidia.com/opensuse/tumbleweed NVIDIA`. For Leap, you can run `sudo zypper addrepo --refresh 'https://download.nvidia.com/opensuse/leap/${releasever}' NVIDIA`.
-2. Install the appropriate driver by running `sudo zypper in x11-video-nvidiaG06` or `sudo zypper in x11-video-nvidiaG05` or `sudo zypper in x11-video-nvidiaG04`
+2. To auto-detect and install the right driver for your hardware, run: `sudo zypper install-new-recommends --repo nvidia` Alternatively you can also specify which version via: `sudo zypper in x11-video-nvidiaG06` or `sudo zypper in x11-video-nvidiaG05` or `sudo zypper in x11-video-nvidiaG04`
 3. Reboot.
 
 #### CUDA

--- a/project/docs/install_proprietary.md
+++ b/project/docs/install_proprietary.md
@@ -23,7 +23,11 @@
 
 #### Using the command line
 1. Add the Nvidia Repository. If using Tumbleweed for example, you would run `sudo zypper addrepo --refresh https://download.nvidia.com/opensuse/tumbleweed NVIDIA`. For Leap, you can run `sudo zypper addrepo --refresh 'https://download.nvidia.com/opensuse/leap/${releasever}' NVIDIA`.
-2. To auto-detect and install the right driver for your hardware, run: `sudo zypper install-new-recommends --repo nvidia` Alternatively you can also specify which version via: `sudo zypper in x11-video-nvidiaG06` or `sudo zypper in x11-video-nvidiaG05` or `sudo zypper in x11-video-nvidiaG04`
+2. To auto-detect and install the right driver for your hardware, run:
+   `sudo zypper install-new-recommends --repo nvidia` Alternatively you can also specify which version with:
+   `sudo zypper in x11-video-nvidiaG06` or 
+   `sudo zypper in x11-video-nvidiaG05` or 
+   `sudo zypper in x11-video-nvidiaG04` (you can use `zypper se -s x11-video-nvidia` to help you determine which driver best fits your hardware`).
 3. Reboot.
 
 #### CUDA


### PR DESCRIPTION
adding the option of a user installation of the flathub repo which allows auto-updates, which is default with e.g. Fedora and other distros

Nvidia drivers: adding under command line the option to use `zypper install-new-recommends --repo nvidia` as a way to auto-detect the users hardware.