### PR TITLE
Getting some technical details right and textual improvements

### DIFF
--- a/project/docs/best_of_post.md
+++ b/project/docs/best_of_post.md
@@ -14,15 +14,6 @@ $   sudo zypper dup
 ```
 
 
-### Take advantage of zypper's concurrent downloader
-The backend for the `zypper` package manager recently got a more efficient downloader, able to download data concurrently. You can turn it on by setting the `ZYPP_MEDIANETWORK` environment variable to `1`:
-
-```
-$   export ZYPP_MEDIANETWORK=1
-```
-
-To set this variable at every boot, add the same command line to your shell's initialization file (i.e. `~/.bashrc`, `~/bash_profile`, etc).
-
 ### Get used to adding repositories with auto-refresh on
 When you add repositories to Tumbleweed, those do not have their auto-refresh setting on by default. This means that doing `sudo zypper dup` might report no pending updates when in fact there __are__ updates, but those were just not seen by the package manager. To change this behavior and ensure that your system will always hook up to repositories with auto-refresh enabled, make sure you add repositories with auto-refresh on:
 ```

--- a/project/docs/codecs.md
+++ b/project/docs/codecs.md
@@ -1,15 +1,9 @@
 ## Installing Codecs 
 
-!!! Warning
-   The _packman_ repository is not officially supported, not an _openSUSE_ maintained repository, contains software that is not compatible with the _GPL_, and can potentially break multimedia in the system such as _pipewire_ or _wireplumber_.
-
-You need to play online or offline multimedia content, but the content does not play or you receive errors. Usually this is a sign of missing codecs. Due to legal limitations proprietary codecs can't be stored and served directly from the __openSUSE__/__SUSE__ infrastructure. To install proprietary codec packages you will need to add the [Packman](http://packman.links2linux.org/) repository and install the required software from there. Some commonly used and installed codecs are:
+You need to play online or offline multimedia content, but the content does not play or you receive errors. Usually this is a sign of missing codecs. Due to legal limitations patent-encumbered codecs can't be distributed directly from the __openSUSE__/__SUSE__ infrastructure. To install these codec packages you will need to add the community-supported [Packman](http://packman.links2linux.org/) repository and install the required software from there. Some commonly installed codecs from this repository are:
 
 - ffmpeg
-- gstreamer-plugins-good
-- gstreamer-plugins-bad
 - gstreamer-plugins-libav
-- gstreamer-plugins-ugly
 - libavcodec-full
 - vlc-codecs
 

--- a/project/docs/pipewire.md
+++ b/project/docs/pipewire.md
@@ -17,16 +17,12 @@ Install the package:
 sudo zypper in pipewire pipewire-pulseaudio
 ```
 
-Then enable the pipewire audio socket:
+Then enable pipewire sockets and session manager:
 
 ```
-systemctl --user enable --now pipewire.{service,socket}
-systemctl --user enable --now pipewire-pulse.{service,socket}
+systemctl --user enable --now pipewire.socket
+systemctl --user enable --now pipewire-pulse.socket
 systemctl --user enable --now wireplumber.service
 ```
 
-Finally reboot your system:
-
-```
-systemctl reboot
-```
+Pipewire services will be started automatically when needed.

--- a/project/docs/snapper.md
+++ b/project/docs/snapper.md
@@ -262,7 +262,7 @@ You might also want to make sure the `/.snapshots` entry point is correctly regi
 
 If this is not the case edit the `fstab` file accordingly:
 
-`$  sudo nano /etc/fstab`
+`$  EDITOR=nano sudoedit /etc/fstab`
 
 pasting on a new line
 

--- a/project/docs/updating_upgrading_reverting.md
+++ b/project/docs/updating_upgrading_reverting.md
@@ -132,6 +132,9 @@ These informations will enable you to find a directory on a path of type: `https
 $   sudo zypper in -f --oldpackage <path/to/kernel package.rpm>
 ```
 
+!!! info
+    If you have any out-of-tree (external) kernel module installed, you'll need `kernel-devel` (in `noarch` directory) and `kernel-default-devel` (`<your-cpu-architecture>`) from a matching version.
+
 `zypper` will take care of writing a new GRUB entry for the newly installed old kernel, but it is likely to place the new entry _below_ the entries for the more recent kernel entry or entries you are staying away from. If you want to set the new entry as default, follow the path below and select the entry listed at the end:
 
 * _YaST_ > _Bootloader_ > _Bootloader Options_ > _Default Boot Section_ > __`<new kernel entry>`__ (select it)

--- a/project/docs/updating_upgrading_reverting.md
+++ b/project/docs/updating_upgrading_reverting.md
@@ -68,7 +68,7 @@ For either scenario to work, you will need to configure your system to accept us
 Open zypper configuration file:
 
 ```
-$   sudo nano /etc/zypp/zypp.conf
+$   EDITOR=nano sudoedit /etc/zypp/zypp.conf
 ```
 
 Make sure that the line `multiversion = provides:multiversion(kernel)` is not commented out (make sure there is no `#` prepended to `multiversion = provides:multiversion(kernel)`). If the line is commented out, use the arrow keys to bring the cursor near the `#` and delete it.

--- a/project/docs/zstd.md
+++ b/project/docs/zstd.md
@@ -1,14 +1,16 @@
 ## Enable zstd compression
 
 !!! Warning
-    Currently _Leap_ doesn't support `zstd`, do not enable it!
+    Use `zstd` exclusively on _Tumbleweed_ as _Leap_ 15.x doesn't support it.
 
-First enable `zstd` compression on `/` (root) and `/home` by adding the corresponding parameters to `/etc/fstab`:
+First enable `zstd` compression on `/` (rootfs) by adding `compress=zstd:1` mount option to `/etc/fstab`:
 
 ```
 <UUID> / btrfs compress=zstd:1 0 0
-<UUID> /home btrfs subvol=/@/home,compress=zstd:1 0 0
+<UUID> /home btrfs subvol=/@/home 0 0
 ```
+
+Once set, this mount option applies to any subvolumes mounted from the same filesystem.
 
 This will apply `zstd` compression to all the files directly under the relevant directories. The files already present under these directories will not be touched, however. To retroactively compress them, use:
 


### PR DESCRIPTION
- Add a infobox on out-of-tree kernel modules
- btrfs compress needs to be set in rootfs
- Prefer sudoedit to sudo
- Pipewire services can be started from sockets
- Incorporate Packman project status in main text
- ZYPP_MEDIANETWORK is no more